### PR TITLE
changed to opendns for ip fetch

### DIFF
--- a/src/public_ip2.widget/script.sh
+++ b/src/public_ip2.widget/script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-IP="$(curl -4fNs https://api.ipify.org/?format=text)"
+IP="$(dig @resolver1.opendns.com ANY myip.opendns.com +short)"
 COUNTRY="$(curl -4fNs https://ipapi.co/$IP/country/)"
 echo $IP "http://www.geognos.com/api/en/countries/flag/$COUNTRY.png"


### PR DESCRIPTION
using a dns server to fetch IP is more reliable since DNS servers tend to last longer.